### PR TITLE
Recognize apps that have mixed-case directory names in the tail command

### DIFF
--- a/app/Commands/TailCommand.php
+++ b/app/Commands/TailCommand.php
@@ -34,7 +34,7 @@ class TailCommand extends Command
 
         $app = $this->resolveAppToTail($configRepository);
 
-        $appServices = $supervisordRepository->getAllProcessInfo()->where('group', str($app)->slug());
+        $appServices = $supervisordRepository->getAllProcessInfo()->where('group', $app);
 
         if ($this->option('all') === false) {
             $servicesToTail = $this->choice(
@@ -58,11 +58,20 @@ class TailCommand extends Command
     private function resolveAppToTail(ConfigRepository $config): mixed
     {
         return $this->argument('app') ??
-            $config->apps->firstWhere('dir', getcwd())['name'] ??
-            $this->choice(
-                'Which app do you want to tail?',
-                $config->apps->pluck('name')->toArray(),
-            );
+               $this->getAppFromCwd($config) ??
+               $this->choice(
+                   'Which app do you want to tail?',
+                   $config->apps->pluck('name')
+                                ->map(fn ($name) => str($name)->slug())
+                                ->toArray(),
+               );
+    }
+
+    private function getAppFromCwd(ConfigRepository $config): ?string
+    {
+        $app = $config->apps->firstWhere('dir', getcwd())['name'] ?? null;
+
+        return $app !== null ? str($app)->slug() : null;
     }
 
     private function tail(Collection $files)

--- a/app/Commands/TailCommand.php
+++ b/app/Commands/TailCommand.php
@@ -34,7 +34,7 @@ class TailCommand extends Command
 
         $app = $this->resolveAppToTail($configRepository);
 
-        $appServices = $supervisordRepository->getAllProcessInfo()->where('group', $app);
+        $appServices = $supervisordRepository->getAllProcessInfo()->where('group', str($app)->slug());
 
         if ($this->option('all') === false) {
             $servicesToTail = $this->choice(


### PR DESCRIPTION
My app is in a directory named `ClientPlatform`. When the `supervisord` config file is written, it slugs the app's name when determining the group name:

https://github.com/anystack-sh/porter/blob/c9bb7a6742b9b3dc8e95a326b5af90951382c2e1/app/Repositories/ConfigRepository.php#L154-L157

This results in the app being `clientplatform`:

<img width="529" alt="image" src="https://user-images.githubusercontent.com/748444/209757392-c15f6072-fc9c-4d00-be94-4c841c6784c4.png">

When calling `porter tail`, if you _don't_ pass an app name, it uses the current working directory to figure out what the current app is: (line 61)

https://github.com/anystack-sh/porter/blob/c9bb7a6742b9b3dc8e95a326b5af90951382c2e1/app/Commands/TailCommand.php#L58-L66

A truncated list of app configs shows the name as `ClientPlatform` - with the mixed case:

```json
{"dir":"\/Users\/scott\/dev\/ClientPlatform","name":"ClientPlatform","config":{}}
```

When the tail command queries the `supervisord` processes by group, it passes the app name to the query - which in my case is `ClientPlatform` - resulting in no matching processes, since the group name is slugged as `clientplatform`.

https://github.com/anystack-sh/porter/blob/c9bb7a6742b9b3dc8e95a326b5af90951382c2e1/app/Commands/TailCommand.php#L35-L37

This PR slugs the app name before passing it to the group query, to match what happens when the `supervisord` conf file is written. It does this in two places:
1. When matching the app's `dir` value to the value of `getcwd()`
2. When plucking `name` from all of the apps

If the user provides an `app` argument, it is not changed in any way.