### PR TITLE
Fix minimum php version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.0"
+        "php": "^8.1"
     },
     "require-dev": {
         "laravel/pint": "^1.2",


### PR DESCRIPTION
Hello 👋🏻 

In this PR I have updated minimum php version requirement to `php^8.1` since `symfony/yaml^6.2` requires so.

![Screenshot 2023-01-11 120636](https://user-images.githubusercontent.com/60013703/211791716-815c94f4-5316-44cb-babc-b5a5266cb8a1.png)