### PR TITLE
Directly call `$this->getOutput()->write()` to avoid an extra newline in the `tail` command

### DIFF
--- a/app/Commands/TailCommand.php
+++ b/app/Commands/TailCommand.php
@@ -88,7 +88,7 @@ class TailCommand extends Command
                 $line = fgets($$name);
 
                 if ($line !== false) {
-                    $this->line($line);
+                    $this->getOutput()->write($line);
                 } else {
                     usleep(0.1 * 1000000);
                     fseek($$name, ftell($$name));


### PR DESCRIPTION
Currently, the `tail` command calls `$this->line($line)`, which in turn calls `$this->getOutput()->writeln($line)`. Since the log file is being read with `fgets()`, `$line` includes the ending newline character. Passing this to `writeln()` appends another newline character, resulting in an empty/blank line between each output line:

<img width="489" alt="Screenshot 2023-10-24 at 2 02 01 PM" src="https://github.com/anystack-sh/porter/assets/748444/ccaa8cdf-f8f5-4bde-a67b-349d0889d689">

---

This change simply directly calls `$this->getOutput()->write($line)` to avoid appending an extra newline character:

<img width="490" alt="Screenshot 2023-10-24 at 2 02 12 PM" src="https://github.com/anystack-sh/porter/assets/748444/23ed298e-f086-4f60-8229-16e4edaff57e">

---

This resolves #12