### PR TITLE
Add a `--services` option to the `tail` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,10 @@ To monitor your services you can use the `porter status` command.
 ```
 
 ### Tail service logs
-You can tail one or more services (unified) using the `porter tail` command. This command is context-aware and will automatically ask which services do you want to tail:
+
+#### Basic tail usage
+You can tail one or more services (unified) using the `porter tail` command.
+This command is context-aware and will automatically ask which services you want to tail:
 
 ```shell
 ~/Developer/anystack: $ porter tail
@@ -125,6 +128,58 @@ You can tail one or more services (unified) using the `porter tail` command. Thi
  Local: http://127.0.0.1:8000
  200    GET / ... 33.38 mb 79.10 ms
  ```
+
+#### Tail all available services
+
+To automatically tail all available services, pass the `--all` option:
+
+```shell
+~/Developer/anystack: $ porter tail --all
+ Use CTRL+C to stop tailing.
+ 
+ Horizon started successfully.
+ 
+ INFO  Server running…
+ Local: http://127.0.0.1:8000
+ 200    GET / ... 33.38 mb 79.10 ms
+```
+
+#### Tail one or more services
+
+You can specify one or more services that you would like to tail by passing
+the `--services` option with a comma-separated list of service indexes or service names.
+You can find the index and name of each available service by running `porter tail` with no arguments:
+
+```shell
+~/Developer/anystack: $ porter tail
+
+ Which service do you want to tail?:
+  [0] anystack-octane
+  [1] anystack-queue
+  [2] anystack-vite
+```
+
+The following examples reference the service names and indexes found above:
+
+```shell
+~/Developer/anystack: $ porter tail --services=0,2
+```
+
+```shell
+~/Developer/anystack: $ porter tail --services=anystack-octane,anystack-vite
+```
+
+_The above two commands are functionally equivalent._
+
+```shell
+~/Developer/anystack: $ porter tail --services=1
+```
+
+```shell
+~/Developer/anystack: $ porter tail --services=anystack-queue
+```
+
+_The above two commands are functionally equivalent._
 
 ### All available commands
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ To monitor your services you can use the `porter status` command.
 
 #### Basic tail usage
 You can tail one or more services (unified) using the `porter tail` command.
+
 This command is context-aware and will automatically ask which services you want to tail:
 
 ```shell
@@ -146,8 +147,9 @@ To automatically tail all available services, pass the `--all` option:
 
 #### Tail one or more services
 
-You can specify one or more services that you would like to tail by passing
+You can specify one or more services that you would like to tail by passing  
 the `--services` option with a comma-separated list of service indexes or service names.
+
 You can find the index and name of each available service by running `porter tail` with no arguments:
 
 ```shell

--- a/app/Commands/TailCommand.php
+++ b/app/Commands/TailCommand.php
@@ -44,11 +44,14 @@ class TailCommand extends Command
             $servicesToTail = $this->resolveServicesToTail($appServices);
         }
 
+        $this->comment('Tailing services:');
+        $this->table([], collect($servicesToTail ?? $appServices->pluck('name'))
+            ->map(fn ($service) => [$service])->toArray());
+        $this->comment('Use CTRL+C to stop tailing.');
+
         $files = $appServices
             ->when(isset($servicesToTail), fn ($c) => $c->whereIn('name', $servicesToTail))
             ->pluck('stdout_logfile');
-
-        $this->comment('Use CTRL+C to stop tailing.');
 
         $this->tail($files);
     }

--- a/app/Commands/TailCommand.php
+++ b/app/Commands/TailCommand.php
@@ -5,7 +5,6 @@ namespace App\Commands;
 use App\Repositories\ConfigRepository;
 use App\Repositories\SupervisordRepository;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
 use LaravelZero\Framework\Commands\Command;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 
@@ -93,7 +92,7 @@ class TailCommand extends Command
             return null;
         }
 
-        return Str::of($services)
+        return str($services)
             ->explode(',')
             ->map(function ($service) use ($appServices) {
                 if (is_numeric($service) && isset($appServices[$service])) {

--- a/app/Commands/TailCommand.php
+++ b/app/Commands/TailCommand.php
@@ -5,7 +5,9 @@ namespace App\Commands;
 use App\Repositories\ConfigRepository;
 use App\Repositories\SupervisordRepository;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use LaravelZero\Framework\Commands\Command;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
 
 class TailCommand extends Command
 {
@@ -14,7 +16,10 @@ class TailCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'tail {app?} {--all}';
+    protected $signature = 'tail
+                            {app?}
+                            {--services= : Comma-separated list of service indexes (e.g. 0,1) or service names to tail}
+                            {--all}';
 
     /**
      * The description of the command.
@@ -37,13 +42,7 @@ class TailCommand extends Command
         $appServices = $supervisordRepository->getAllProcessInfo()->where('group', $app);
 
         if ($this->option('all') === false) {
-            $servicesToTail = $this->choice(
-                'Which service do you want to tail?',
-                $appServices->pluck('name')->toArray(),
-                null,
-                null,
-                true
-            );
+            $servicesToTail = $this->resolveServicesToTail($appServices);
         }
 
         $files = $appServices
@@ -72,6 +71,44 @@ class TailCommand extends Command
         $app = $config->apps->firstWhere('dir', getcwd())['name'] ?? null;
 
         return $app !== null ? str($app)->slug() : null;
+    }
+
+    private function resolveServicesToTail(Collection $appServices): mixed
+    {
+        return $this->getServicesFromOption($appServices) ??
+            $this->choice(
+                'Which service do you want to tail?',
+                $appServices->pluck('name')->toArray(),
+                null,
+                null,
+                true
+            );
+    }
+
+    private function getServicesFromOption(Collection $appServices): mixed
+    {
+        $services = $this->option('services');
+
+        if (empty($services)) {
+            return null;
+        }
+
+        return Str::of($services)
+            ->explode(',')
+            ->map(function ($service) use ($appServices) {
+                if (is_numeric($service) && isset($appServices[$service])) {
+                    return $appServices[$service]['name'];
+                }
+
+                if ($appServices->contains('name', $service)) {
+                    return $service;
+                }
+
+                throw new InvalidArgumentException("Service \"$service\" is invalid");
+            })
+            ->filter()
+            ->unique()
+            ->toArray() ?: null;
     }
 
     private function tail(Collection $files)

--- a/app/Commands/TailCommand.php
+++ b/app/Commands/TailCommand.php
@@ -19,7 +19,7 @@ class TailCommand extends Command
     protected $signature = 'tail
                             {app?}
                             {--services= : Comma-separated list of service indexes (e.g. 0,1) or service names to tail}
-                            {--all}';
+                            {--all : Tail all available services (overrides --services option)}';
 
     /**
      * The description of the command.


### PR DESCRIPTION
I felt that it would be helpful to be able to specify one or more services to tail, rather than having to either do all or go through an interactive choice. This PR adds a `--services` option that lets you specify one or more service indexes and/or names to be tailed.

[The relevant section of the readme](https://github.com/squatto/porter/blob/39963fd1c0976fed7e32b8815b19cea298a5b0bd/README.md?plain=1#L148-L184) shows how this works:

---

#### Tail one or more services

You can specify one or more services that you would like to tail by passing  
the `--services` option with a comma-separated list of service indexes or service names.

You can find the index and name of each available service by running `porter tail` with no arguments:

```shell
~/Developer/anystack: $ porter tail

 Which service do you want to tail?:
  [0] anystack-octane
  [1] anystack-queue
  [2] anystack-vite
```

The following examples reference the service names and indexes found above:

```shell
~/Developer/anystack: $ porter tail --services=0,2
```

```shell
~/Developer/anystack: $ porter tail --services=anystack-octane,anystack-vite
```

_The above two commands are functionally equivalent._

```shell
~/Developer/anystack: $ porter tail --services=1
```

```shell
~/Developer/anystack: $ porter tail --services=anystack-queue
```

_The above two commands are functionally equivalent._

---

I didn't mention it in the readme, but you can mix indexes and names and they'll resolve correctly. For example, `--services=anystack-octane,1,anystack-vite` will resolve `1` to the `anystack-queue` service.

As part of this change, the list of services that are being tailed is output before tailing. This happens regardless of the options provided.

```
$ tail

 Which service do you want to tail?:
  [0] clientplatform-horizon
  [1] clientplatform-sync-tunnels
  [2] clientplatform-watch-horizon
  [3] clientplatform-yarn-watch
 > 0,1

Tailing services:
+-----------------------------+
| clientplatform-horizon      |
| clientplatform-sync-tunnels |
+-----------------------------+
Use CTRL+C to stop tailing.
```